### PR TITLE
Fixups for Ambari 2.4

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -7,6 +7,7 @@ class ambari::agent(
   $service_name              = $::ambari::params::agent_service_name,
   $service_ensure            = $::ambari::params::agent_service_ensure,
   $service_enable            = $::ambari::params::agent_service_enable,
+  $tmp_dir                 = $::ambari::params::agent_tmp_dir,
   $use_repo                  = $::ambari::params::agent_use_repo, ) inherits ::ambari::params {
 
   contain ::ambari::agent::install

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -7,7 +7,7 @@ class ambari::agent(
   $service_name              = $::ambari::params::agent_service_name,
   $service_ensure            = $::ambari::params::agent_service_ensure,
   $service_enable            = $::ambari::params::agent_service_enable,
-  $tmp_dir                 = $::ambari::params::agent_tmp_dir,
+  $tmp_dir                   = $::ambari::params::agent_tmp_dir,
   $use_repo                  = $::ambari::params::agent_use_repo, ) inherits ::ambari::params {
 
   contain ::ambari::agent::install

--- a/manifests/agent/config.pp
+++ b/manifests/agent/config.pp
@@ -3,6 +3,7 @@ class ambari::agent::config() {
   $ambari_server = $::ambari::agent::ambari_server
   $ambari_server_port = $::ambari::agent::ambari_server_port
   $ambari_server_secure_port = $::ambari::agent::ambari_server_secure_port
+  $tmp_dir = $::ambari::agent::tmp_dir
 
   file { '/etc/ambari-agent/conf/ambari-agent.ini':
     ensure  => 'file',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,5 +9,6 @@ class ambari::params {
   $agent_service_name = 'ambari-agent'
   $agent_service_ensure = 'running'
   $agent_service_enable = true
+  $agent_tmp_dir = '/var/lib/ambari-agent/data/tmp'
   $agent_use_repo = true
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,6 +9,6 @@ class ambari::params {
   $agent_service_name = 'ambari-agent'
   $agent_service_ensure = 'running'
   $agent_service_enable = true
-  $agent_tmp_dir = '/var/lib/ambari-agent/data/tmp'
+  $agent_tmp_dir = '/var/lib/ambari-agent/tmp'
   $agent_use_repo = true
 }

--- a/templates/agent/ambari-agent.ini.erb
+++ b/templates/agent/ambari-agent.ini.erb
@@ -18,6 +18,8 @@ url_port=<%= @ambari_server_port %>
 secured_url_port=<%= @ambari_server_secure_port %>
 
 [agent]
+logdir=/var/log/ambari-agent
+piddir=/var/run/ambari-agent
 prefix=/var/lib/ambari-agent/data
 tmp_dir=<%= @tmp_dir %>
 ;loglevel=(DEBUG/INFO)
@@ -30,6 +32,9 @@ cache_dir=/var/lib/ambari-agent/cache
 tolerate_download_failures=true
 run_as_user=root
 parallel_execution=0
+alert_grace_period=5
+alert_kinit_timeout=14400000
+system_resource_overrides=/etc/resource_overrides
 
 [security]
 keysdir=/var/lib/ambari-agent/keys
@@ -40,12 +45,15 @@ passphrase_env_var_name=AMBARI_PASSPHRASE
 pidLookupPath=/var/run/
 
 [heartbeat]
-state_interval=6
+state_interval_seconds=60
 dirs=/etc/hadoop,/etc/hadoop/conf,/etc/hbase,/etc/hcatalog,/etc/hive,/etc/oozie,
   /etc/sqoop,/etc/ganglia,
   /var/run/hadoop,/var/run/zookeeper,/var/run/hbase,/var/run/templeton,/var/run/oozie,
   /var/log/hadoop,/var/log/zookeeper,/var/log/hbase,/var/run/templeton,/var/log/hive
 ; 0 - unlimited
 log_lines_count=300
+idle_interval_min=1
+idle_interval_max=10
 
 [logging]
+syslog_enabled=0

--- a/templates/agent/ambari-agent.ini.erb
+++ b/templates/agent/ambari-agent.ini.erb
@@ -19,7 +19,7 @@ secured_url_port=<%= @ambari_server_secure_port %>
 
 [agent]
 prefix=/var/lib/ambari-agent/data
-tmp_dir=/var/lib/ambari-agent/data/tmp
+tmp_dir=<%= @tmp_dir %>
 ;loglevel=(DEBUG/INFO)
 loglevel=INFO
 data_cleanup_interval=86400


### PR DESCRIPTION
Updates config to be safe for Ambari 2.4.1.0, otherwise the module causes a variable to be unreferenced, and a stray chown blows out the host its run on.